### PR TITLE
use --host 0.0.0.0 in `yarn start`

### DIFF
--- a/packages/console-app/package.json
+++ b/packages/console-app/package.json
@@ -14,7 +14,7 @@
     "clean": "rm -rf dist",
     "dist": "yarn clean && yarn build:babel && CONFIG_FILE=config-production.yml webpack",
     "lint": "semistandard 'src/**/*.js'",
-    "start": "CONFIG_FILE=${CONFIG_FILE:-config-testnet.yml} VERBOSE=true webpack-dev-server --mode development",
+    "start": "CONFIG_FILE=${CONFIG_FILE:-config-testnet.yml} VERBOSE=true webpack-dev-server --host 0.0.0.0 --mode development",
     "test": "jest --rootDir ./src --passWithNoTests --no-cache"
   },
   "author": "",


### PR DESCRIPTION
Makes the console work out of the box in a cloud droplet. Eventually redundant when the console is integrated in SO but this is nice for dev purposes. If running locally; 127.0.0.1:8080 works rather than localhost:8080