### PR TITLE
Bump laconic-sdk to 0.1.6

### DIFF
--- a/packages/console-app/package.json
+++ b/packages/console-app/package.json
@@ -29,7 +29,7 @@
     "@apollo/react-components": "^3.1.5",
     "@apollo/react-hooks": "^3.1.5",
     "@babel/runtime": "^7.8.7",
-    "@cerc-io/laconic-sdk": "0.1.4",
+    "@cerc-io/laconic-sdk": "0.1.6",
     "@lirewine/debug": "1.0.0-beta.78",
     "@lirewine/gem-core": "1.0.0-beta.28",
     "@lirewine/react-ux": "1.1.0-beta.0",


### PR DESCRIPTION
- use the latest release of the sdk